### PR TITLE
 [OWL-543] let NQM to calcaulte RTT median and RTT mdev

### DIFF
--- a/cfg.go
+++ b/cfg.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Cepave/common/model"
 	"github.com/toolkits/file"
 )
 
@@ -156,12 +155,6 @@ func loadJSONConfig() {
 
 func GetGeneralConfig() *GeneralConfig {
 	return generalConfig
-}
-
-func SetGeneralConfigByAgent(agent model.NqmAgent) {
-	GetGeneralConfig().ISP = agent.IspName
-	GetGeneralConfig().Province = agent.ProvinceName
-	GetGeneralConfig().City = agent.CityName
 }
 
 func InitGeneralConfig() {

--- a/data_test.go
+++ b/data_test.go
@@ -97,18 +97,10 @@ func TestNqmTagsAssembler(t *testing.T) {
 }
 
 func init() {
-	/*var (
-	  agentData *nqmEndpointData
-	  )
-	*/
-	// agentData is initialized for testMarshalIntoParameters.
-	agentData = &nqmEndpointData{
-		Id:         "1000",
-		IspId:      "1001",
-		ProvinceId: "1002",
-		CityId:     "1003",
-		NameTagId:  "1004",
-	}
+	// Hostname is the config dependency which lies in func MarshalIntoParameters
+	var cfg GeneralConfig
+	generalConfig = &cfg
+	cfg.Hostname = "unit-test-hostname"
 }
 
 func TestMarshalIntoParameters(t *testing.T) {
@@ -120,6 +112,7 @@ func TestMarshalIntoParameters(t *testing.T) {
 		"www.google.com : 13.24 38.90 19.62 9.48 13.62",
 		"www.yahoo.com : 6.72 29.08 8.55 7.40 - 6.26",
 	}
+
 	var test_target_list []model.NqmTarget
 	for i, _ := range tests {
 		t := model.NqmTarget{
@@ -136,7 +129,18 @@ func TestMarshalIntoParameters(t *testing.T) {
 		test_target_list = append(test_target_list, t)
 	}
 
-	out := MarshalIntoParameters(tests, test_target_list)
+	var test_agent_ptr = &model.NqmAgent{
+		Id:           1,
+		Name:         "agent_for_test",
+		IspId:        2,
+		IspName:      "IspName_for_test",
+		ProvinceId:   3,
+		ProvinceName: "ProvinceName_for_test",
+		CityId:       4,
+		CityName:     "CityName_for_test",
+	}
+
+	out := MarshalIntoParameters(tests, test_target_list, test_agent_ptr)
 	t.Log(out)
 	//t.Log(test_target_list)
 }

--- a/data_test.go
+++ b/data_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/Cepave/common/model"
 	"reflect"
 	"testing"
 )
@@ -27,20 +28,50 @@ func TestNqmParseFpingRow(t *testing.T) {
 	}
 }
 
+func TestNqmFpingStat(t *testing.T) {
+	tests := [][]string{
+		{"www.google.com", "13.24", "38.90", "19.62", "9.48", "13.62"},
+		{"www.yahoo.com", "6.72", "29.08", "8.55", "7.40", "-", "6.26"},
+		{"www.null.com", "-", "-", "-"},
+	}
+
+	/*
+	   data_test.go:37: map[pkttransmit:5 pktreceive:5 rttmin:9.48 rttmax:38.90 rttavg:18.97 rttmdev:10.48 rttmedian:13.62]
+	   data_test.go:37: map[rttmedian:7.40 pkttransmit:6 pktreceive:5 rttmin:6.26 rttmax:29.08 rttavg:11.60 rttmdev:8.77]
+	*/
+	expecteds := []map[string]string{
+		{"rttmax": "38.90", "rttavg": "18.97", "rttmdev": "10.48", "rttmedian": "13.62", "pkttransmit": "5", "pktreceive": "5", "rttmin": "9.48"},
+		{"rttmdev": "8.77", "rttmedian": "7.40", "pkttransmit": "6", "pktreceive": "5", "rttmin": "6.26", "rttmax": "29.08", "rttavg": "11.60"},
+		{"rttmdev": "-1", "rttmedian": "-1", "pkttransmit": "3", "pktreceive": "0", "rttmin": "-1", "rttmax": "-1", "rttavg": "-1"},
+	}
+
+	for i, v := range tests {
+		if !reflect.DeepEqual(expecteds[i], nqmFpingStat(v)) {
+			t.Error(expecteds[i], nqmFpingStat(v))
+		}
+		t.Log(nqmFpingStat(v))
+	}
+}
+
 func TestParseFpingRow(t *testing.T) {
 	tests := []string{
 		"www.google.com : xmt/rcv/%loss = 100/100/0%, min/avg/max = 8.61/14.5/46.5",
 		"www.yahoo.com  : xmt/rcv/%loss = 100/99/1%, min/avg/max = 5.42/10.9/35.9",
+		"www.google.com : 13.24 38.90 19.62 9.48 13.62",
+		"www.yahoo.com : 6.72 29.08 8.55 7.40 - 6.26",
 	}
 
 	expecteds := [][]string{
 		{"www.google.com", "xmt", "rcv", "loss", "100", "100", "0", "min", "avg", "max", "8.61", "14.5", "46.5"},
 		{"www.yahoo.com", "xmt", "rcv", "loss", "100", "99", "1", "min", "avg", "max", "5.42", "10.9", "35.9"},
+		{"www.google.com", "13.24", "38.90", "19.62", "9.48", "13.62"},
+		{"www.yahoo.com", "6.72", "29.08", "8.55", "7.40", "-", "6.26"},
 	}
 	for i, v := range tests {
 		if !reflect.DeepEqual(expecteds[i], parseFpingRow(v)) {
 			t.Error(expecteds[i], parseFpingRow(v))
 		}
+		t.Log(parseFpingRow(v))
 	}
 }
 
@@ -63,4 +94,49 @@ func TestNqmTagsAssembler(t *testing.T) {
 	if t_out != expecteds[0] {
 		t.Error(expecteds[0], t_out)
 	}
+}
+
+func init() {
+	/*var (
+	  agentData *nqmEndpointData
+	  )
+	*/
+	// agentData is initialized for testMarshalIntoParameters.
+	agentData = &nqmEndpointData{
+		Id:         "1000",
+		IspId:      "1001",
+		ProvinceId: "1002",
+		CityId:     "1003",
+		NameTagId:  "1004",
+	}
+}
+
+func TestMarshalIntoParameters(t *testing.T) {
+	/*
+	   www.google.com : 21.77 15.88 14.57 18.94 17.23
+	   www.yahoo.com  : 12.86 7.67 6.81 6.96 8.65
+	*/
+	tests := []string{
+		"www.google.com : 13.24 38.90 19.62 9.48 13.62",
+		"www.yahoo.com : 6.72 29.08 8.55 7.40 - 6.26",
+	}
+	var test_target_list []model.NqmTarget
+	for i, _ := range tests {
+		t := model.NqmTarget{
+			Id:           i,
+			Host:         "test host",
+			IspId:        int16(i),
+			IspName:      "test isp",
+			ProvinceId:   int16(i),
+			ProvinceName: "test province",
+			CityId:       int16(i),
+			CityName:     "test city",
+			NameTag:      "test nametag",
+		}
+		test_target_list = append(test_target_list, t)
+	}
+
+	out := MarshalIntoParameters(tests, test_target_list)
+	t.Log(out)
+	//t.Log(test_target_list)
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ func main() {
 	InitGeneralConfig()
 	InitRPC()
 
-	probingCmd, targets, err := QueryTask()
+	probingCmd, targets, agentPtr, err := QueryTask()
 	if err != nil {
 		log.Println(err)
 		return
@@ -18,7 +18,7 @@ func main() {
 	log.Println("Execution the probing command:", probingCmd[0])
 
 	rawData := Probe(probingCmd)
-	jsonParams := MarshalIntoParameters(rawData, targets)
+	jsonParams := MarshalIntoParameters(rawData, targets, agentPtr)
 	Push(jsonParams)
 	//	log.Println(jsonParams)
 }

--- a/main.go
+++ b/main.go
@@ -2,14 +2,16 @@ package main
 
 import "log"
 
+//*
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	InitGeneralConfig()
 	InitRPC()
 }
 
+//*/
 func main() {
-	probingCmd, err := QueryTask()
+	probingCmd, targets, err := QueryTask()
 	if err != nil {
 		log.Println(err)
 		return
@@ -17,7 +19,7 @@ func main() {
 	log.Println("Execution the probing command:", probingCmd[0])
 
 	rawData := Probe(probingCmd)
-	jsonParams := MarshalIntoParameters(rawData)
+	jsonParams := MarshalIntoParameters(rawData, targets)
 	Push(jsonParams)
 	//	log.Println(jsonParams)
 }

--- a/probe_test.go
+++ b/probe_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+)
+
+// fping -p 20 -i 10 -C 5 -a www.google.com www.yahoo.com
+func TestProbe(t *testing.T) {
+	tests := []string{
+		"fping", "-p", "20", "-i", "10", "-C", "5", "-a",
+		"www.google.com",
+		"www.yahoo.com",
+	}
+
+	t.Log("input cmd is:", tests)
+	expected := Probe(tests)
+	for _, v := range expected {
+		t.Log(v)
+	}
+}

--- a/task.go
+++ b/task.go
@@ -39,13 +39,13 @@ func targetToNqmEndpointData(s *model.NqmTarget) *nqmEndpointData {
 	}
 }
 
-func QueryTask() ([]string, error) {
+func QueryTask() ([]string, []model.NqmTarget, error) {
 	err := rpcClient.Call("NqmAgent.PingTask", req, &resp)
 	if err != nil {
 		log.Fatalln("Call NqmAgent.PingTask error:", err)
 	}
 	if !resp.NeedPing {
-		return []string{}, fmt.Errorf("No tasks assigned.")
+		return []string{}, resp.Targets, fmt.Errorf("No tasks assigned.")
 	}
 	agent := *resp.Agent
 	SetGeneralConfigByAgent(agent)
@@ -57,5 +57,5 @@ func QueryTask() ([]string, error) {
 	}
 
 	probingCmd := append(resp.Command, targetAddressList...)
-	return probingCmd, nil
+	return probingCmd, resp.Targets, nil
 }

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"reflect"
+	"testing"
+
+	"github.com/Cepave/common/model"
+)
+
+type NqmAgent int
+
+func (t *NqmAgent) PingTask(request model.NqmPingTaskRequest, response *model.NqmPingTaskResponse) (err error) {
+	response.NeedPing = true
+
+	nqmAgent := &model.NqmAgent{
+		Id:           1,
+		Name:         "agent_for_test",
+		IspId:        2,
+		IspName:      "IspName_for_test",
+		ProvinceId:   3,
+		ProvinceName: "ProvinceName_for_test",
+		CityId:       4,
+		CityName:     "CityName_for_test",
+	}
+	response.Agent = nqmAgent
+
+	targets := []model.NqmTarget{
+		{Id: 11, IspId: 12, ProvinceId: 13, CityId: 14},
+		{Id: 21, IspId: 22, ProvinceId: 23, CityId: 24},
+		{Id: 31, IspId: 32, ProvinceId: 33, CityId: 34},
+	}
+	response.Targets = targets
+
+	response.Command = []string{"fping", "-p", "20", "-i", "10", "-c", "4", "-q", "-a"}
+	return nil
+}
+
+func initJsonRpcServer(addr string) {
+	rpc.Register(new(NqmAgent))
+
+	l, e := net.Listen("tcp", addr)
+	if e != nil {
+		panic(fmt.Errorf("Cannot listen to address %v. Error %v", addr, e))
+	} else {
+		log.Println("RPC server is listening at", addr)
+	}
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				log.Println("listener accept fail:", err)
+				break
+			}
+			go jsonrpc.ServeConn(conn)
+		}
+	}()
+}
+
+func initJsonRpcClient(srvAddr string) {
+	rpcClient.RpcServer = srvAddr
+}
+
+func TestQueryTask(t *testing.T) {
+	initJsonRpcServer("127.0.0.1:65534")
+	initJsonRpcClient("127.0.0.1:65534")
+
+	cmd, targetList, err := QueryTask()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expecteds := []model.NqmTarget{
+		{Id: 11, IspId: 12, ProvinceId: 13, CityId: 14},
+		{Id: 21, IspId: 22, ProvinceId: 23, CityId: 24},
+		{Id: 31, IspId: 32, ProvinceId: 33, CityId: 34},
+	}
+	for i, v := range targetList {
+		if !reflect.DeepEqual(expecteds[i], v) {
+			t.Error(v)
+		}
+	}
+
+	t.Log(cmd)
+}

--- a/task_test.go
+++ b/task_test.go
@@ -36,7 +36,7 @@ func (t *NqmAgent) PingTask(request model.NqmPingTaskRequest, response *model.Nq
 	}
 	response.Targets = targets
 
-	response.Command = []string{"fping", "-p", "20", "-i", "10", "-c", "4", "-q", "-a"}
+	response.Command = []string{"fping", "-p", "20", "-i", "10", "-C", "4", "-q", "-a"}
 	return nil
 }
 
@@ -64,13 +64,18 @@ func initJsonRpcServer(addr string) {
 
 func initJsonRpcClient(srvAddr string) {
 	rpcClient.RpcServer = srvAddr
+	req = model.NqmPingTaskRequest{
+		Hostname:     "nqm-agent",
+		IpAddress:    "1.2.3.4",
+		ConnectionId: "arg-arg-arg",
+	}
 }
 
 func TestQueryTask(t *testing.T) {
 	initJsonRpcServer("127.0.0.1:65534")
 	initJsonRpcClient("127.0.0.1:65534")
 
-	cmd, targetList, err := QueryTask()
+	cmd, targetList, agent, err := QueryTask()
 	if err != nil {
 		t.Error(err)
 	}
@@ -86,5 +91,6 @@ func TestQueryTask(t *testing.T) {
 		}
 	}
 
+	t.Log(agent)
 	t.Log(cmd)
 }

--- a/test/math.py
+++ b/test/math.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python 
+
+import numpy as np
+
+#{"www.google.com", "13.24", "38.90", "19.62", "9.48", "13.62"},
+#{"www.yahoo.com", "6.72", "29.08", "8.55", "7.40", "-", "6.26"},
+
+
+a=[13.24, 38.90, 19.62, 9.48, 13.62] 
+data_a = np.array(a)
+print "For array", a
+print "median", np.median(data_a)
+print "dev", np.std(data_a)
+print "max", max(a)
+print "min", min(a)
+print "average", np.mean(data_a)
+
+
+b=[6.72, 29.08, 8.55, 7.40, 6.26]
+data_b = np.array(b) 
+print "For array", b
+print "median", np.median(data_b)
+print "dev", np.std(data_b)
+print "max", max(b)
+print "min", min(b)
+print "average", np.mean(data_b)


### PR DESCRIPTION
# [OWL-543]
1. First part is functional
   Original NQM asks HBS to get fping command as
   `fping -p 20 -i 10 -c 100 -a www.google.com`
   The probe will get something like
   `www.google.com : xmt/rcv/%loss = 5/5/0%, min/avg/max = 9.97/12.7/15.2`
   
   This version, NQM will ask HBS to get fping command as
   `fping -p 20 -i 10 -C 5 -a www.google.com www.yahoo.com`
   The probe will get
   `www.google.com : 13.24 38.90 19.62 9.48 13.62`
   `www.yahoo.com : 6.72 29.08 8.55 7.40 6.26`
   Therefore, we can calculate RTT median and RTT mdev.
2. Add more unit test. Reduce code dependency from config file. 
