### PR TITLE
[OWL-504] Fix the pkt content error

### DIFF
--- a/data.go
+++ b/data.go
@@ -86,7 +86,8 @@ func nqmMarshalJSON(target model.NqmTarget, metric string, row []string) ParamTo
 	data.Timestamp = time.Now().Unix()
 	data.Endpoint = "nqm-endpoint"
 	data.Value = "0"
-	data.CounterType = "nqm"
+	data.CounterType = "GAUGE"
+	data.Step = int64(60)
 	return data
 }
 


### PR DESCRIPTION
On the integration test with transfer, pkt to **transfer** was discarded because of some content check in **transfer**.

For example, the transfer limit the **CounterType** must be _GAUGE_, _DERIVE_, or _COUNTER_, and **Step** must be _bigger than zero_.
