### PR TITLE
Fix the pkt content error and improve unit test.

### DIFF
--- a/data.go
+++ b/data.go
@@ -86,7 +86,8 @@ func nqmMarshalJSON(target model.NqmTarget, metric string, row []string) ParamTo
 	data.Timestamp = time.Now().Unix()
 	data.Endpoint = "nqm-endpoint"
 	data.Value = "0"
-	data.CounterType = "nqm"
+	data.CounterType = "GAUGE"
+	data.Step = int64(60)
 	return data
 }
 

--- a/data_test.go
+++ b/data_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/Cepave/common/model"
+	"github.com/Cepave/transfer/g"
 	"reflect"
 	"testing"
 )
@@ -142,5 +143,30 @@ func TestMarshalIntoParameters(t *testing.T) {
 
 	out := MarshalIntoParameters(tests, test_target_list, test_agent_ptr)
 	t.Log(out)
-	//t.Log(test_target_list)
+	for _, v := range out {
+		// implement the pkt check in transfer.
+		if v.Metric == "kernel.hostname" {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+
+		if v.Metric == "" || v.Endpoint == "" {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+
+		if v.CounterType != g.COUNTER && v.CounterType != g.GAUGE && v.CounterType != g.DERIVE {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+
+		if v.Value == "" {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+
+		if v.Step <= 0 {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+
+		if len(v.Metric)+len(v.Tags) > 510 {
+			t.Error("Can not pass the pkt check in transfer.", v)
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 		log.Println(err)
 		return
 	}
-	log.Println("Execution the probing command:", probingCmd[0])
+	log.Println("Execution the probing command:", probingCmd[0:9])
 
 	rawData := Probe(probingCmd)
 	jsonParams := MarshalIntoParameters(rawData, targets, agentPtr)


### PR DESCRIPTION
1. Fix the content error.
   
   On the integration test with transfer, pkt to transfer was discarded because of some content check in transfer.  
2. Add pkt checking mechanism in transfer into Unit Test. 
   
    NQM sends pkt to transfer. However, transfer will check the pkt  and even discard some pkts which   are not valid. Add pkt checking mechanism in to Unit Test can improve the integration between NQM and transfer.
